### PR TITLE
Request only host keys with SSH ClientConfig

### DIFF
--- a/cmd/servegeecerts/server-main.go
+++ b/cmd/servegeecerts/server-main.go
@@ -61,11 +61,16 @@ func (s *SSOServer) makeHostCert(w http.ResponseWriter, h string) {
 	var certToReturn []byte
 	var kt string
 
+	// Derived from ssh.common.supportedHostKeyAlgos with certificate host key types removed
+	var supportedHostKeyAlgos = []string{
+		ssh.KeyAlgoECDSA256, ssh.KeyAlgoECDSA384, ssh.KeyAlgoECDSA521, ssh.KeyAlgoRSA, ssh.KeyAlgoDSA, ssh.KeyAlgoED25519,
+	}
 	ssh.Dial("tcp", fmt.Sprintf("%s:%d", h, s.Config.SshConnectForPublickeyPort), &ssh.ClientConfig{
 		User: "ca",
 		Auth: []ssh.AuthMethod{
 			ssh.Password("wrongpassignoreme"),
 		},
+		HostKeyAlgorithms: supportedHostKeyAlgos,
 		HostKeyCallback: func(hostname string, remote net.Addr, key ssh.PublicKey) error {
 			if key == nil {
 				return errors.New("no host key")


### PR DESCRIPTION
Resolves an issue where attempting to sign certificates that were being returned rather than host keys resulted in "panic: unknown cert key type ecdsa-sha2-nistp256-cert-v01@openssh.com"

```
panic: unknown cert key type ecdsa-sha2-nistp256-cert-v01@openssh.com                                                                 
goroutine 8914 [running]:                                                                                                             
github.com/continusec/geecert/vendor/golang.org/x/crypto/ssh.(*Certificate).Type(0xc00028b9f8, 0xc0005a2b00, 0x535)                   
        /go/src/github.com/continusec/geecert/vendor/golang.org/x/crypto/ssh/certs.go:496 +0x10e                                      
github.com/continusec/geecert/vendor/golang.org/x/crypto/ssh.(*Certificate).Marshal(0xc00028b9f8, 0x40d279, 0xc00059f720, 0x20)       
        /go/src/github.com/continusec/geecert/vendor/golang.org/x/crypto/ssh/certs.go:484 +0x38b                                      
github.com/continusec/geecert/vendor/golang.org/x/crypto/ssh.(*Certificate).bytesForSigning(0xc00028bb88, 0xa4e7e0, 0xc000171080, 0x20
)                                                                                                                                     
        /go/src/github.com/continusec/geecert/vendor/golang.org/x/crypto/ssh/certs.go:454 +0x69                                       
github.com/continusec/geecert/vendor/golang.org/x/crypto/ssh.(*Certificate).SignCert(0xc00028bb88, 0xa44c60, 0xc000072750, 0xa497c0, 0
xc0005976c0, 0x110f41ccce68b, 0xe01d60)                                                                                               
        /go/src/github.com/continusec/geecert/vendor/golang.org/x/crypto/ssh/certs.go:423 +0x103                                      
main.CreateHostCertificate(0xc000025396, 0x19, 0xa4e6e0, 0xc000099a20, 0xc000171080, 0x4e94914f0000, 0xc0004f5d66, 0x13, 0x61, 0xc0002
8bcd8, ...)                                                                                                                           
        /go/src/github.com/continusec/geecert/cmd/servegeecerts/server-main.go:251 +0x279                                             
main.(*SSOServer).makeHostCert.func1(0xc00057fa00, 0x1f, 0xa4a400, 0xc000230810, 0xa4e6e0, 0xc000099a20, 0x0, 0x0)                    
        /go/src/github.com/continusec/geecert/cmd/servegeecerts/server-main.go:78 +0xfe                                               
github.com/continusec/geecert/vendor/golang.org/x/crypto/ssh.(*handshakeTransport).client(0xc00021c2c0, 0xa49580, 0xe1e6a0, 0xc0002538
80, 0xc000170de0, 0x1, 0x0, 0x1)                                                                                                      
        /go/src/github.com/continusec/geecert/vendor/golang.org/x/crypto/ssh/handshake.go:641 +0x188                                  
github.com/continusec/geecert/vendor/golang.org/x/crypto/ssh.(*handshakeTransport).enterKeyExchange(0xc00021c2c0, 0xc00010d700, 0x51a,
 0x51a, 0xc000037f01, 0x6d8c0f)                                                                                                       
        /go/src/github.com/continusec/geecert/vendor/golang.org/x/crypto/ssh/handshake.go:587 +0x6a7                                  
github.com/continusec/geecert/vendor/golang.org/x/crypto/ssh.(*handshakeTransport).kexLoop(0xc00021c2c0)                              
        /go/src/github.com/continusec/geecert/vendor/golang.org/x/crypto/ssh/handshake.go:301 +0x1ce                                  
created by github.com/continusec/geecert/vendor/golang.org/x/crypto/ssh.newClientTransport                                            
        /go/src/github.com/continusec/geecert/vendor/golang.org/x/crypto/ssh/handshake.go:135 +0x1a3  
```